### PR TITLE
GitHub Actionワークフローを追加：ビルドとリリースの自動化

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,71 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'  # タグがv*（例: v1.0.0）の形式でプッシュされた時にトリガー
+    branches:
+      - main
+      - master
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
+    - name: List available schemes
+      run: xcodebuild -list -project boringNotch.xcodeproj
+
+    - name: Build app
+      run: |
+        xcodebuild -project boringNotch.xcodeproj \
+          -scheme boringNotch \
+          -configuration Release \
+          -derivedDataPath DerivedData \
+          -archivePath DerivedData/Archive/boringNotch.xcarchive \
+          archive \
+          CODE_SIGN_IDENTITY="" \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGNING_ALLOWED=NO
+
+    - name: Export app
+      run: |
+        # アーカイブからアプリを取得
+        cp -r DerivedData/Archive/boringNotch.xcarchive/Products/Applications/boringNotch.app .
+
+        # ZIPファイルを作成
+        ditto -c -k --keepParent boringNotch.app boringNotch.zip
+
+    - name: Get version from tag
+      id: get_version
+      run: |
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        else
+          echo "VERSION=dev-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: boringNotch-${{ steps.get_version.outputs.VERSION }}
+        path: boringNotch.zip
+
+    - name: Create Release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v2
+      with:
+        files: boringNotch.zip
+        draft: false
+        prerelease: false
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- タグv*がプッシュされた時にmacOSアプリをビルドしてリリースを作成
- mainブランチへのプッシュでもビルドを実行（アーティファクトのみ）
- softprops/action-gh-releaseを使用して自動リリースノート生成
- コード署名なしでビルド（後で追加可能）