### PR TITLE
永続的なメモウィジェット機能を追加

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -125,6 +125,8 @@
 		A1C1B0AE2E77780200000010 /* ClipboardMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C1B0AD2E77770200000010 /* ClipboardMenuView.swift */; };
 		A1C1B0AE2E77780300000010 /* ClipboardMenuBarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C1B0AD2E77770300000010 /* ClipboardMenuBarManager.swift */; };
         A1C1B0AE2E77780500000010 /* NotchClipboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C1B0AD2E77770500000010 /* NotchClipboardView.swift */; };
+	A1D1C0AE2E88880100000020 /* MemoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D1C0AD2E88880100000020 /* MemoManager.swift */; };
+	A1D1C0AE2E88880200000020 /* NotchMemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D1C0AD2E88880200000020 /* NotchMemoView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -263,6 +265,8 @@
 		A1C1B0AD2E77770200000010 /* ClipboardMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardMenuView.swift; sourceTree = "<group>"; };
 		A1C1B0AD2E77770300000010 /* ClipboardMenuBarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardMenuBarManager.swift; sourceTree = "<group>"; };
         A1C1B0AD2E77770500000010 /* NotchClipboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchClipboardView.swift; sourceTree = "<group>"; };
+	A1D1C0AD2E88880100000020 /* MemoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoManager.swift; sourceTree = "<group>"; };
+	A1D1C0AD2E88880200000020 /* NotchMemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchMemoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -372,6 +376,7 @@
 				A1B2C3D42E00000100000001 /* AirPodsConnectToast.swift */,
 				A1B2C3D62E00000100000001 /* LockStatusBanner.swift */,
 				A1C1B0AF2E77780300000011 /* Clipboard */,
+				A1D1C0AF2E88880300000021 /* Memo */,
 			);
 			path = components;
 			sourceTree = "<group>";
@@ -383,6 +388,14 @@
 				A1C1B0AD2E77770500000010 /* NotchClipboardView.swift */,
 			);
 			path = Clipboard;
+			sourceTree = "<group>";
+		};
+		A1D1C0AF2E88880300000021 /* Memo */ = {
+			isa = PBXGroup;
+			children = (
+				A1D1C0AD2E88880200000020 /* NotchMemoView.swift */,
+			);
+			path = Memo;
 			sourceTree = "<group>";
 		};
 		147163B52C5D804B0068B555 /* managers */ = {
@@ -399,6 +412,7 @@
 
 				A1C1B0AD2E77770100000010 /* ClipboardHistoryManager.swift */,
 				A1C1B0AD2E77770300000010 /* ClipboardMenuBarManager.swift */,
+				A1D1C0AD2E88880100000020 /* MemoManager.swift */,
 			);
 			path = managers;
 			sourceTree = "<group>";
@@ -851,6 +865,8 @@
 				11CFC6612E097F6800748C80 /* PermissionsRequestView.swift in Sources */,
 				14D570D22C5F6C6A0011E668 /* BoringExtrasMenu.swift in Sources */,
 				14288DDC2C6E015000B9F80C /* AudioPlayer.swift in Sources */,
+				A1D1C0AE2E88880100000020 /* MemoManager.swift in Sources */,
+				A1D1C0AE2E88880200000020 /* NotchMemoView.swift in Sources */,
 				149E0B972C737D00006418B1 /* WebcamManager.swift in Sources */,
 				14288E0C2C6F8EC000B9F80C /* AppIcons.swift in Sources */,
 				B1C448982C972CC4001F0858 /* ListItemPopover.swift in Sources */,

--- a/boringNotch/components/Memo/NotchMemoView.swift
+++ b/boringNotch/components/Memo/NotchMemoView.swift
@@ -1,0 +1,327 @@
+//
+//  NotchMemoView.swift
+//  boringNotch
+//
+//  Persistent memo widget for the notch header
+//
+
+import SwiftUI
+import Defaults
+
+struct NotchMemoView: View {
+    @ObservedObject var memoManager = MemoManager.shared
+    @State private var isExpanded = false
+    @State private var showingAddSheet = false
+    @State private var editingItem: MemoItem?
+    @State private var newMemoText = ""
+    @State private var editMemoText = ""
+    @FocusState private var isTextFieldFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if !memoManager.items.isEmpty {
+                // Compact view showing memo count
+                Button(action: {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                        isExpanded.toggle()
+                    }
+                }) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "note.text")
+                            .font(.system(size: 12, weight: .medium))
+                        Text("\(memoManager.items.count)")
+                            .font(.system(size: 11, weight: .semibold))
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .font(.system(size: 10, weight: .semibold))
+                    }
+                    .foregroundColor(.white.opacity(0.8))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(.white.opacity(0.1))
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
+                .help("メモ")
+            }
+
+            // Add button (always visible)
+            Button(action: {
+                showingAddSheet = true
+                newMemoText = ""
+            }) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(.white.opacity(0.7))
+            }
+            .buttonStyle(PlainButtonStyle())
+            .help("メモを追加")
+        }
+        .popover(isPresented: $isExpanded, arrowEdge: .bottom) {
+            MemoListPopover(
+                memoManager: memoManager,
+                editingItem: $editingItem,
+                editMemoText: $editMemoText
+            )
+        }
+        .sheet(isPresented: $showingAddSheet) {
+            AddMemoSheet(
+                newMemoText: $newMemoText,
+                isTextFieldFocused: _isTextFieldFocused,
+                onAdd: {
+                    if !newMemoText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        memoManager.addItem(text: newMemoText)
+                        showingAddSheet = false
+                        newMemoText = ""
+                    }
+                },
+                onCancel: {
+                    showingAddSheet = false
+                    newMemoText = ""
+                }
+            )
+        }
+        .sheet(item: $editingItem) { item in
+            EditMemoSheet(
+                editMemoText: $editMemoText,
+                isTextFieldFocused: _isTextFieldFocused,
+                onSave: {
+                    if !editMemoText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        memoManager.updateItem(id: item.id, text: editMemoText)
+                        editingItem = nil
+                    }
+                },
+                onCancel: {
+                    editingItem = nil
+                }
+            )
+        }
+    }
+}
+
+// MARK: - Memo List Popover
+struct MemoListPopover: View {
+    @ObservedObject var memoManager: MemoManager
+    @Binding var editingItem: MemoItem?
+    @Binding var editMemoText: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Text("メモ")
+                    .font(.system(size: 14, weight: .semibold))
+                Spacer()
+                if !memoManager.items.isEmpty {
+                    Button(action: {
+                        memoManager.clearAll()
+                    }) {
+                        Text("全て削除")
+                            .font(.system(size: 11))
+                            .foregroundColor(.red.opacity(0.8))
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            // List
+            if memoManager.items.isEmpty {
+                VStack(spacing: 12) {
+                    Image(systemName: "note.text")
+                        .font(.system(size: 32))
+                        .foregroundColor(.gray.opacity(0.5))
+                    Text("メモがありません")
+                        .font(.system(size: 13))
+                        .foregroundColor(.gray)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 120)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(memoManager.items) { item in
+                            MemoItemRow(
+                                item: item,
+                                onEdit: {
+                                    editMemoText = item.text
+                                    editingItem = item
+                                },
+                                onDelete: {
+                                    memoManager.deleteItem(id: item.id)
+                                }
+                            )
+                            if item.id != memoManager.items.last?.id {
+                                Divider()
+                                    .padding(.leading, 16)
+                            }
+                        }
+                    }
+                }
+                .frame(height: min(CGFloat(memoManager.items.count * 60), 300))
+            }
+        }
+        .frame(width: 320)
+        .background(.ultraThinMaterial)
+    }
+}
+
+// MARK: - Memo Item Row
+struct MemoItemRow: View {
+    let item: MemoItem
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.text)
+                    .font(.system(size: 13))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(timeAgo(from: item.updatedAt))
+                    .font(.system(size: 10))
+                    .foregroundColor(.gray)
+            }
+
+            Spacer()
+
+            if isHovering {
+                HStack(spacing: 8) {
+                    Button(action: onEdit) {
+                        Image(systemName: "pencil")
+                            .font(.system(size: 12))
+                            .foregroundColor(.blue)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .help("編集")
+
+                    Button(action: onDelete) {
+                        Image(systemName: "trash")
+                            .font(.system(size: 12))
+                            .foregroundColor(.red)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .help("削除")
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            isHovering = hovering
+        }
+    }
+
+    private func timeAgo(from date: Date) -> String {
+        let seconds = Date().timeIntervalSince(date)
+        if seconds < 60 {
+            return "今"
+        } else if seconds < 3600 {
+            return "\(Int(seconds / 60))分前"
+        } else if seconds < 86400 {
+            return "\(Int(seconds / 3600))時間前"
+        } else {
+            return "\(Int(seconds / 86400))日前"
+        }
+    }
+}
+
+// MARK: - Add Memo Sheet
+struct AddMemoSheet: View {
+    @Binding var newMemoText: String
+    @FocusState var isTextFieldFocused: Bool
+    let onAdd: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("新しいメモ")
+                .font(.system(size: 16, weight: .semibold))
+
+            TextEditor(text: $newMemoText)
+                .font(.system(size: 14))
+                .frame(height: 120)
+                .padding(8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                )
+                .focused($isTextFieldFocused)
+
+            HStack(spacing: 12) {
+                Button("キャンセル") {
+                    onCancel()
+                }
+                .keyboardShortcut(.escape)
+
+                Button("追加") {
+                    onAdd()
+                }
+                .keyboardShortcut(.return)
+                .disabled(newMemoText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(24)
+        .frame(width: 400)
+        .onAppear {
+            isTextFieldFocused = true
+        }
+    }
+}
+
+// MARK: - Edit Memo Sheet
+struct EditMemoSheet: View {
+    @Binding var editMemoText: String
+    @FocusState var isTextFieldFocused: Bool
+    let onSave: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("メモを編集")
+                .font(.system(size: 16, weight: .semibold))
+
+            TextEditor(text: $editMemoText)
+                .font(.system(size: 14))
+                .frame(height: 120)
+                .padding(8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                )
+                .focused($isTextFieldFocused)
+
+            HStack(spacing: 12) {
+                Button("キャンセル") {
+                    onCancel()
+                }
+                .keyboardShortcut(.escape)
+
+                Button("保存") {
+                    onSave()
+                }
+                .keyboardShortcut(.return)
+                .disabled(editMemoText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(24)
+        .frame(width: 400)
+        .onAppear {
+            isTextFieldFocused = true
+        }
+    }
+}
+
+#Preview {
+    NotchMemoView()
+        .frame(width: 600, height: 100)
+        .background(.black)
+}

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -44,6 +44,10 @@ struct BoringHeader: View {
 
             HStack(spacing: 4) {
                 if vm.notchState == .open {
+                    // Memo widget
+                    if Defaults[.showMemoWidget] {
+                        NotchMemoView()
+                    }
                     if Defaults[.showMirror] {
                         Button(action: {
                             vm.toggleCameraPreview()

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -931,6 +931,7 @@ struct Appearance: View {
             Section {
                 Toggle("Always show tabs", isOn: $coordinator.alwaysShowTabs)
                 Defaults.Toggle("Settings icon in notch", key: .settingsIconInNotch)
+                Defaults.Toggle("Show memo widget", key: .showMemoWidget)
                 Defaults.Toggle("Enable window shadow", key: .enableShadow)
                 Defaults.Toggle("Corner radius scaling", key: .cornerRadiusScaling)
                 Defaults.Toggle("Use simpler close animation", key: .useModernCloseAnimation)

--- a/boringNotch/managers/MemoManager.swift
+++ b/boringNotch/managers/MemoManager.swift
@@ -1,0 +1,114 @@
+//
+//  MemoManager.swift
+//  boringNotch
+//
+//  Manages persistent memo items for the notch header
+//
+
+import Foundation
+import Combine
+
+struct MemoItem: Identifiable, Codable, Equatable {
+    let id: UUID
+    var text: String
+    var order: Int
+    let createdAt: Date
+    var updatedAt: Date
+
+    init(id: UUID = UUID(), text: String, order: Int, createdAt: Date = Date(), updatedAt: Date = Date()) {
+        self.id = id
+        self.text = text
+        self.order = order
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+class MemoManager: ObservableObject {
+    static let shared = MemoManager()
+
+    @Published private(set) var items: [MemoItem] = []
+
+    private let storageKey = "persistentMemoItems"
+
+    private init() {
+        loadItems()
+    }
+
+    // MARK: - Public Methods
+
+    func addItem(text: String) {
+        let newOrder = items.isEmpty ? 0 : (items.map { $0.order }.max() ?? 0) + 1
+        let newItem = MemoItem(text: text, order: newOrder)
+        items.append(newItem)
+        saveItems()
+    }
+
+    func updateItem(id: UUID, text: String) {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        items[index].text = text
+        items[index].updatedAt = Date()
+        saveItems()
+    }
+
+    func deleteItem(id: UUID) {
+        items.removeAll { $0.id == id }
+        // Re-order remaining items
+        for (index, item) in items.enumerated() {
+            items[index].order = index
+        }
+        saveItems()
+    }
+
+    func deleteItem(at offsets: IndexSet) {
+        items.remove(atOffsets: offsets)
+        // Re-order remaining items
+        for (index, _) in items.enumerated() {
+            items[index].order = index
+        }
+        saveItems()
+    }
+
+    func moveItem(from source: IndexSet, to destination: Int) {
+        items.move(fromOffsets: source, toOffset: destination)
+        // Update order for all items
+        for (index, _) in items.enumerated() {
+            items[index].order = index
+        }
+        saveItems()
+    }
+
+    func clearAll() {
+        items.removeAll()
+        saveItems()
+    }
+
+    // MARK: - Private Methods
+
+    private func loadItems() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey) else {
+            items = []
+            return
+        }
+
+        do {
+            let decoder = JSONDecoder()
+            items = try decoder.decode([MemoItem].self, from: data)
+            // Sort by order
+            items.sort { $0.order < $1.order }
+        } catch {
+            print("Failed to load memo items: \(error)")
+            items = []
+        }
+    }
+
+    private func saveItems() {
+        do {
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(items)
+            UserDefaults.standard.set(data, forKey: storageKey)
+        } catch {
+            print("Failed to save memo items: \(error)")
+        }
+    }
+}

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -157,7 +157,10 @@ extension Defaults.Keys {
     
     // MARK: Clipboard
     static let enableClipboardMenuBar = Key<Bool>("enableClipboardMenuBar", default: true)
-    
+
+    // MARK: Memo
+    static let showMemoWidget = Key<Bool>("showMemoWidget", default: true)
+
     // Helper to determine the default media controller based on macOS version
     static var defaultMediaController: MediaControllerType {
         if #available(macOS 15.4, *) {


### PR DESCRIPTION
HUDの上部navに、再起動しても保持されるメモウィジェットを追加しました。

主な機能：
- メモの追加、編集、削除
- UserDefaultsによる永続化
- コンパクトな表示（メモ数のみ表示）
- ポップオーバーでメモリスト表示
- 設定画面でのトグル機能

実装内容：
- MemoManager.swift: メモデータの管理と永続化
- NotchMemoView.swift: メモウィジェットのUI
- BoringHeader.swift: ヘッダーへの統合
- Constants.swift: 設定キーの追加
- SettingsView.swift: 設定画面への追加